### PR TITLE
Update frontCartSimulation.js

### DIFF
--- a/prestashop-v1.6-1.7/scalexpertplugin/views/js/ps16/frontCartSimulation.js
+++ b/prestashop-v1.6-1.7/scalexpertplugin/views/js/ps16/frontCartSimulation.js
@@ -38,7 +38,7 @@ $(function () {
                     type: 'financial'
                 },
                 beforeSend: clearResult()
-            }).success(function (jsonData) {
+            }).done(function (jsonData) {
                 successAjax(jsonData);
             });
         }


### PR DESCRIPTION
.success() is deprecated since jQuery 1.8; .done() offers better Promise-based handling and compatibility.